### PR TITLE
Feat/shellfish production density

### DIFF
--- a/jsonld-contexts/shellfish-farming.jsonld
+++ b/jsonld-contexts/shellfish-farming.jsonld
@@ -23,6 +23,7 @@
         "decreeComment": "https://schema.org/decreeComment",
         "decreeFile": "https://schema.org/decreeFile",
         "decreeTitle": "https://schema.org/decreeTitle",
+        "density": "https://smart-data-models.org/density",
         "expiryDate": "https://smart-data-models.org/expiryDate",
         "familyName": "https://schema.org/familyName",
         "familyOfUse": "https://smart-data-models.org/familyOfUse",

--- a/ngsild-payloads/ShellfishBatchProduction/Shellfish-Batch-Production.jsonld
+++ b/ngsild-payloads/ShellfishBatchProduction/Shellfish-Batch-Production.jsonld
@@ -24,7 +24,7 @@
   "density": {
     "type": "Property",
     "value": 5,
-    "unitCode": "MTK",
+    "unitCode": "MTR",
     "observedAt": "1970-01-01T00:00:00Z"
   },
   "size": {

--- a/ngsild-payloads/ShellfishBatchProduction/Shellfish-Batch-Production.jsonld
+++ b/ngsild-payloads/ShellfishBatchProduction/Shellfish-Batch-Production.jsonld
@@ -21,6 +21,12 @@
     "value": 2000,
     "observedAt": "1970-01-01T00:00:00Z"
   },
+  "density": {
+    "type": "Property",
+    "value": 10,
+    "unitCode": "C62",
+    "observedAt": "1970-01-01T00:00:00Z"
+  },
   "size": {
     "type": "Property",
     "value": "T8",

--- a/ngsild-payloads/ShellfishBatchProduction/Shellfish-Batch-Production.jsonld
+++ b/ngsild-payloads/ShellfishBatchProduction/Shellfish-Batch-Production.jsonld
@@ -23,8 +23,8 @@
   },
   "density": {
     "type": "Property",
-    "value": 10,
-    "unitCode": "C62",
+    "value": 5,
+    "unitCode": "MTK",
     "observedAt": "1970-01-01T00:00:00Z"
   },
   "size": {


### PR DESCRIPTION
Added the density attribute to the ShellfishBatchProduction entity.

Please note that unitCode can be either "C62" (in this case, the density of the entire structure) or "MTK" for square meter. MTK applies only to the structure "Corde"