### PR TITLE
feat: added status batch production

### DIFF
--- a/ngsild-payloads/ShellfishBatchProduction/Shellfish-Batch-Production.jsonld
+++ b/ngsild-payloads/ShellfishBatchProduction/Shellfish-Batch-Production.jsonld
@@ -47,7 +47,7 @@
   },
   "status": {
     "type": "Property",
-    "value": "Harvested",
+    "value": "'Harvested' or 'In production'",
     "observedAt": "1970-01-01T00:00:00Z"
   },
   "belongsToBatch": {

--- a/ngsild-payloads/ShellfishBatchProduction/Shellfish-Batch-Production.jsonld
+++ b/ngsild-payloads/ShellfishBatchProduction/Shellfish-Batch-Production.jsonld
@@ -45,6 +45,11 @@
     "type": "Property",
     "value": "2025-01-31T00:00:00.000Z"
   },
+  "status": {
+    "type": "Property",
+    "value": "Harvested",
+    "observedAt": "1970-01-01T00:00:00Z"
+  },
   "belongsToBatch": {
     "type": "Relationship",
     "object": "urn:ngsi-ld:ShellfishBatch:1234"


### PR DESCRIPTION
Added status to the ShellfishBatchProduction payload. The attribute property already existed in the context.

This attribute should take the following values as its value:

- "In production"
- "Harvested"

The goal is to give a clear idea of when the production was harvested. The productionEndDate should also reflect the same date as the observedAt of the status IF the value is "Harvested".