### PR TITLE
feat: added the attribute harvest notes

### DIFF
--- a/jsonld-contexts/shellfish-farming.jsonld
+++ b/jsonld-contexts/shellfish-farming.jsonld
@@ -34,6 +34,7 @@
         "gp1": "https://schema.org/gp1",
         "gp2": "https://schema.org/gp2",
         "gp3": "https://schema.org/gp3",
+        "harvestNotes": "https://smart-data-models.org/harvestNotes",
         "hasPreviousProduction": "https://smart-data-models.org/hasPreviousProduction",
         "hasShellfishTable": "https://smart-data-models.org/hasShellfishTable",
         "hasSubZones": "https://smart-data-models.org/hasSubZones",

--- a/ngsild-payloads/ShellfishBatchProduction/Shellfish-Batch-Production.jsonld
+++ b/ngsild-payloads/ShellfishBatchProduction/Shellfish-Batch-Production.jsonld
@@ -50,6 +50,11 @@
     "value": "'Harvested' or 'In production'",
     "observedAt": "1970-01-01T00:00:00Z"
   },
+  "harvestNotes": {
+    "type": "Property",
+    "value": "Some notes about the harvest. For example, hooray it was good!",
+    "observedAt": "1970-01-01T00:00:00Z"
+  },
   "belongsToBatch": {
     "type": "Relationship",
     "object": "urn:ngsi-ld:ShellfishBatch:1234"


### PR DESCRIPTION
Added an attribute to ShellfishBatchProduction called harvestNotes. The idea is for the time being, it will be a general observation of the harvest, but it allows the possibility to one day add sub attributes to it. I believe that one day we will have more fields of data to add in regards to the harvest and they could all fall under "harvestNotes"