### PR TITLE
feat: add overflow property

### DIFF
--- a/jsonld-contexts/shellfish-farming.jsonld
+++ b/jsonld-contexts/shellfish-farming.jsonld
@@ -51,6 +51,7 @@
         "numberOfBreedingStructures": "https://smart-data-models.org/numberOfBreedingStructures",
         "numberOfIndividuals": "https://smart-data-models.org/numberOfIndividuals",
         "observations": "https://smart-data-models.org/observations",
+        "overflow": "https://smart-data-models.org/overflow",
         "ownerNumber": "https://smart-data-models.org/ownerNumber",
         "parcel": "https://smart-data-models.org/parcel",
         "Person": "https://schema.org/Person",


### PR DESCRIPTION
Used to track overflow alerts. Alerts are associated to zones of the sanitary atlas.